### PR TITLE
feat(CommandExecution) : proper methods for get & complete

### DIFF
--- a/src/main/java/azerty/tguichaoua/mpb/command/SingleCommand.java
+++ b/src/main/java/azerty/tguichaoua/mpb/command/SingleCommand.java
@@ -28,10 +28,8 @@ public final class SingleCommand extends MyCommand {
 		Collection<String> completion = Collections.emptyList();
 		try {
 			for (final CommandArgument<?> arg : arguments) {
-				completion = arg.complete(execution);
+				completion = execution.complete(arg);
 				if (execution.remains() == 0) break;
-				execution.endArgument();
-				execution.dropAllCheckpoints();
 			}
 		} catch (final CommandException ignored) {
 			return Collections.emptyList();

--- a/src/main/java/azerty/tguichaoua/mpb/command/argument/CommandArgument.java
+++ b/src/main/java/azerty/tguichaoua/mpb/command/argument/CommandArgument.java
@@ -23,8 +23,26 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public interface CommandArgument<T> {
+	/**
+	 * Parses the next value.
+	 * <p>
+	 * Should *NOT* be called directly, use {@link CommandExecution#get(CommandArgument)} instead.
+	 *
+	 * @param execution the {@link CommandExecution}
+	 * @return the parsed value
+	 * @throws CommandException if the parsing fail
+	 */
 	T parse(@NotNull CommandExecution execution) throws CommandException;
 
+	/**
+	 * Returns the completion list for this argument.
+	 * <p>
+	 * Should *NOT* be called directly, use {@link CommandExecution#complete(CommandArgument)} instead.
+	 *
+	 * @param execution the {@link CommandExecution}
+	 * @return the completion list
+	 * @throws CommandException if the parsing fail
+	 */
 	default @NotNull Collection<String> complete(@NotNull final CommandExecution execution) throws CommandException {
 		execution.next();
 		return Collections.emptyList();

--- a/src/main/java/azerty/tguichaoua/mpb/command/argument/CommandArgument.java
+++ b/src/main/java/azerty/tguichaoua/mpb/command/argument/CommandArgument.java
@@ -221,7 +221,7 @@ public interface CommandArgument<T> {
 			public @NotNull Collection<String> complete(@NotNull final CommandExecution execution) throws CommandException {
 				Collection<String> complete = Collections.emptyList();
 				for (int i = amount; i > 0 && execution.remains() != 0; i--) {
-					complete = argument.complete(execution);
+					complete = execution.complete(argument);
 				}
 				return complete;
 			}
@@ -243,7 +243,7 @@ public interface CommandArgument<T> {
 			public @NotNull Collection<String> complete(@NotNull final CommandExecution execution) throws CommandException {
 				Collection<String> complete = Collections.emptyList();
 				while (execution.remains() != 0) {
-					complete = argument.complete(execution);
+					complete = execution.complete(argument);
 				}
 				return complete;
 			}

--- a/src/main/java/azerty/tguichaoua/mpb/command/argument/TransformCommandArgument.java
+++ b/src/main/java/azerty/tguichaoua/mpb/command/argument/TransformCommandArgument.java
@@ -19,7 +19,7 @@ public final class TransformCommandArgument<T, R> implements CommandArgument<R> 
 
 	@Override
 	public @NotNull Collection<String> complete(@NotNull final CommandExecution execution) throws CommandException {
-		return source.complete(execution);
+		return execution.complete(source);
 	}
 
 	@FunctionalInterface

--- a/src/main/java/azerty/tguichaoua/mpb/command/argument/cascade/CascadeArgument10.java
+++ b/src/main/java/azerty/tguichaoua/mpb/command/argument/cascade/CascadeArgument10.java
@@ -44,60 +44,60 @@ public final class CascadeArgument10<A, B, C, D, E, F, G, H, I, J> implements Co
 		if (execution.remains() == 0) return complete;
 
 		execution.checkpoint();
-		complete = A.complete(execution);
+		complete = execution.complete(A);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<B> B = toB.apply(execution.get(A));
 		execution.checkpoint();
-		complete = B.complete(execution);
+		complete = execution.complete(B);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<C> C = toC.apply(execution.get(B));
 		execution.checkpoint();
-		complete = C.complete(execution);
+		complete = execution.complete(C);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<D> D = toD.apply(execution.get(C));
 		execution.checkpoint();
-		complete = D.complete(execution);
+		complete = execution.complete(D);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<E> E = toE.apply(execution.get(D));
 		execution.checkpoint();
-		complete = E.complete(execution);
+		complete = execution.complete(E);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<F> F = toF.apply(execution.get(E));
 		execution.checkpoint();
-		complete = F.complete(execution);
+		complete = execution.complete(F);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<G> G = toG.apply(execution.get(F));
 		execution.checkpoint();
-		complete = G.complete(execution);
+		complete = execution.complete(F);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<H> H = toH.apply(execution.get(G));
 		execution.checkpoint();
-		complete = H.complete(execution);
+		complete = execution.complete(H);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<I> I = toI.apply(execution.get(H));
 		execution.checkpoint();
-		complete = I.complete(execution);
+		complete = execution.complete(I);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<J> J = toJ.apply(execution.get(I));
-		return J.complete(execution);
+		return execution.complete(J);
 	}
 
 	// --- Utils ------------------------------------------------------

--- a/src/main/java/azerty/tguichaoua/mpb/command/argument/cascade/CascadeArgument2.java
+++ b/src/main/java/azerty/tguichaoua/mpb/command/argument/cascade/CascadeArgument2.java
@@ -28,12 +28,12 @@ public final class CascadeArgument2<A, B> implements CommandArgument<Pair<A, B>>
 		if (execution.remains() == 0) return complete;
 
 		execution.checkpoint();
-		complete = A.complete(execution);
+		complete = execution.complete(A);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<B> B = toB.apply(execution.get(A));
-		return B.complete(execution);
+		return execution.complete(B);
 	}
 
 	// --- Cascade -------------------------------------------------------

--- a/src/main/java/azerty/tguichaoua/mpb/command/argument/cascade/CascadeArgument3.java
+++ b/src/main/java/azerty/tguichaoua/mpb/command/argument/cascade/CascadeArgument3.java
@@ -30,18 +30,18 @@ public final class CascadeArgument3<A, B, C> implements CommandArgument<Triplet<
 		if (execution.remains() == 0) return complete;
 
 		execution.checkpoint();
-		complete = A.complete(execution);
+		complete = execution.complete(A);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<B> B = toB.apply(execution.get(A));
 		execution.checkpoint();
-		complete = B.complete(execution);
+		complete = execution.complete(B);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<C> C = toC.apply(execution.get(B));
-		return C.complete(execution);
+		return execution.complete(C);
 	}
 
 	// --- Cascade -------------------------------------------------------

--- a/src/main/java/azerty/tguichaoua/mpb/command/argument/cascade/CascadeArgument4.java
+++ b/src/main/java/azerty/tguichaoua/mpb/command/argument/cascade/CascadeArgument4.java
@@ -32,24 +32,24 @@ public final class CascadeArgument4<A, B, C, D> implements CommandArgument<Quart
 		if (execution.remains() == 0) return complete;
 
 		execution.checkpoint();
-		complete = A.complete(execution);
+		complete = execution.complete(A);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<B> B = toB.apply(execution.get(A));
 		execution.checkpoint();
-		complete = B.complete(execution);
+		complete = execution.complete(B);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<C> C = toC.apply(execution.get(B));
 		execution.checkpoint();
-		complete = C.complete(execution);
+		complete = execution.complete(C);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<D> D = toD.apply(execution.get(C));
-		return D.complete(execution);
+		return execution.complete(D);
 	}
 
 	// --- Cascade -------------------------------------------------------

--- a/src/main/java/azerty/tguichaoua/mpb/command/argument/cascade/CascadeArgument5.java
+++ b/src/main/java/azerty/tguichaoua/mpb/command/argument/cascade/CascadeArgument5.java
@@ -34,30 +34,30 @@ public final class CascadeArgument5<A, B, C, D, E> implements CommandArgument<Qu
 		if (execution.remains() == 0) return complete;
 
 		execution.checkpoint();
-		complete = A.complete(execution);
+		complete = execution.complete(A);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<B> B = toB.apply(execution.get(A));
 		execution.checkpoint();
-		complete = B.complete(execution);
+		complete = execution.complete(B);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<C> C = toC.apply(execution.get(B));
 		execution.checkpoint();
-		complete = C.complete(execution);
+		complete = execution.complete(C);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<D> D = toD.apply(execution.get(C));
 		execution.checkpoint();
-		complete = D.complete(execution);
+		complete = execution.complete(D);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<E> E = toE.apply(execution.get(D));
-		return E.complete(execution);
+		return execution.complete(E);
 	}
 
 	// --- Cascade -------------------------------------------------------

--- a/src/main/java/azerty/tguichaoua/mpb/command/argument/cascade/CascadeArgument6.java
+++ b/src/main/java/azerty/tguichaoua/mpb/command/argument/cascade/CascadeArgument6.java
@@ -36,36 +36,36 @@ public final class CascadeArgument6<A, B, C, D, E, F> implements CommandArgument
 		if (execution.remains() == 0) return complete;
 
 		execution.checkpoint();
-		complete = A.complete(execution);
+		complete = execution.complete(A);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<B> B = toB.apply(execution.get(A));
 		execution.checkpoint();
-		complete = B.complete(execution);
+		complete = execution.complete(B);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<C> C = toC.apply(execution.get(B));
 		execution.checkpoint();
-		complete = C.complete(execution);
+		complete = execution.complete(C);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<D> D = toD.apply(execution.get(C));
 		execution.checkpoint();
-		complete = D.complete(execution);
+		complete = execution.complete(D);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<E> E = toE.apply(execution.get(D));
 		execution.checkpoint();
-		complete = E.complete(execution);
+		complete = execution.complete(E);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<F> F = toF.apply(execution.get(E));
-		return F.complete(execution);
+		return execution.complete(F);
 	}
 
 	// --- Cascade -------------------------------------------------------

--- a/src/main/java/azerty/tguichaoua/mpb/command/argument/cascade/CascadeArgument7.java
+++ b/src/main/java/azerty/tguichaoua/mpb/command/argument/cascade/CascadeArgument7.java
@@ -38,42 +38,42 @@ public final class CascadeArgument7<A, B, C, D, E, F, G> implements CommandArgum
 		if (execution.remains() == 0) return complete;
 
 		execution.checkpoint();
-		complete = A.complete(execution);
+		complete = execution.complete(A);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<B> B = toB.apply(execution.get(A));
 		execution.checkpoint();
-		complete = B.complete(execution);
+		complete = execution.complete(B);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<C> C = toC.apply(execution.get(B));
 		execution.checkpoint();
-		complete = C.complete(execution);
+		complete = execution.complete(C);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<D> D = toD.apply(execution.get(C));
 		execution.checkpoint();
-		complete = D.complete(execution);
+		complete = execution.complete(D);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<E> E = toE.apply(execution.get(D));
 		execution.checkpoint();
-		complete = E.complete(execution);
+		complete = execution.complete(E);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<F> F = toF.apply(execution.get(E));
 		execution.checkpoint();
-		complete = F.complete(execution);
+		complete = execution.complete(F);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<G> G = toG.apply(execution.get(F));
-		return G.complete(execution);
+		return execution.complete(G);
 	}
 
 	// --- Cascade -------------------------------------------------------

--- a/src/main/java/azerty/tguichaoua/mpb/command/argument/cascade/CascadeArgument8.java
+++ b/src/main/java/azerty/tguichaoua/mpb/command/argument/cascade/CascadeArgument8.java
@@ -40,48 +40,48 @@ public final class CascadeArgument8<A, B, C, D, E, F, G, H> implements CommandAr
 		if (execution.remains() == 0) return complete;
 
 		execution.checkpoint();
-		complete = A.complete(execution);
+		complete = execution.complete(A);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<B> B = toB.apply(execution.get(A));
 		execution.checkpoint();
-		complete = B.complete(execution);
+		complete = execution.complete(B);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<C> C = toC.apply(execution.get(B));
 		execution.checkpoint();
-		complete = C.complete(execution);
+		complete = execution.complete(C);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<D> D = toD.apply(execution.get(C));
 		execution.checkpoint();
-		complete = D.complete(execution);
+		complete = execution.complete(D);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<E> E = toE.apply(execution.get(D));
 		execution.checkpoint();
-		complete = E.complete(execution);
+		complete = execution.complete(E);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<F> F = toF.apply(execution.get(E));
 		execution.checkpoint();
-		complete = F.complete(execution);
+		complete = execution.complete(F);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<G> G = toG.apply(execution.get(F));
 		execution.checkpoint();
-		complete = G.complete(execution);
+		complete = execution.complete(G);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<H> H = toH.apply(execution.get(G));
-		return H.complete(execution);
+		return execution.complete(H);
 	}
 
 	// --- Cascade -------------------------------------------------------

--- a/src/main/java/azerty/tguichaoua/mpb/command/argument/cascade/CascadeArgument9.java
+++ b/src/main/java/azerty/tguichaoua/mpb/command/argument/cascade/CascadeArgument9.java
@@ -42,54 +42,54 @@ public final class CascadeArgument9<A, B, C, D, E, F, G, H, I> implements Comman
 		if (execution.remains() == 0) return complete;
 
 		execution.checkpoint();
-		complete = A.complete(execution);
+		complete = execution.complete(A);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<B> B = toB.apply(execution.get(A));
 		execution.checkpoint();
-		complete = B.complete(execution);
+		complete = execution.complete(B);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<C> C = toC.apply(execution.get(B));
 		execution.checkpoint();
-		complete = C.complete(execution);
+		complete = execution.complete(C);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<D> D = toD.apply(execution.get(C));
 		execution.checkpoint();
-		complete = D.complete(execution);
+		complete = execution.complete(D);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<E> E = toE.apply(execution.get(D));
 		execution.checkpoint();
-		complete = E.complete(execution);
+		complete = execution.complete(E);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<F> F = toF.apply(execution.get(E));
 		execution.checkpoint();
-		complete = F.complete(execution);
+		complete = execution.complete(F);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<G> G = toG.apply(execution.get(F));
 		execution.checkpoint();
-		complete = G.complete(execution);
+		complete = execution.complete(G);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<H> H = toH.apply(execution.get(G));
 		execution.checkpoint();
-		complete = H.complete(execution);
+		complete = execution.complete(H);
 		if (execution.remains() == 0) return complete;
 		execution.restore();
 
 		final CommandArgument<I> I = toI.apply(execution.get(H));
-		return I.complete(execution);
+		return execution.complete(I);
 	}
 
 	// --- Cascade -------------------------------------------------------


### PR DESCRIPTION
Introduce `CommandExecution#get(CommandArgument)` and `CommandExecution#complete(CommandArgument)` to properly get the parsed value and the completion list.